### PR TITLE
Update variables.md

### DIFF
--- a/content/docs/seclang/variables.md
+++ b/content/docs/seclang/variables.md
@@ -380,14 +380,14 @@ Contains the time, in microseconds, spent writing to persistent storage.
 
 **Supported on Coraza:** TBI
 
-## QUERY_STRING
+## QUERY_STRING
 Contains the query string part of a request URI. The value in QUERY_STRING is always provided raw, without URL decoding taking place.
 
 ```
 SecRule QUERY_STRING "attack" "id:34"
 ```
 
-## REMOTE_ADDR
+## REMOTE_ADDR
 This variable holds the IP address of the remote client.
 
 ```


### PR DESCRIPTION
fix typo for `QUERY_STRING` and `REMOTE_ADDR` without header style