### PR TITLE
Fix broken link (index → docs/quick-start)

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,7 @@
     </div>
     <div class="col-lg-9 col-xl-8 text-center">
       <p class="lead">{{ .Params.lead | safeHTML }}</p>
-      <a class="btn btn-primary btn-lg px-4 mb-2" href="{{ " docs/tutorials/quick-start" | relURL }}" role="button">Get
+      <a class="btn btn-primary btn-lg px-4 mb-2" href="{{ "docs/tutorials/quick-start" | relURL }}" role="button">Get
         started</a>
       <p class="meta">Open-source Apache 2 Licensed. <a href="https://github.com/corazawaf/coraza">GitHub</a></p>
     </div>


### PR DESCRIPTION
A stray space in the link on the index page breaks the link to quick start docs.

`href="{{ " docs/tutorials/quick-start" | relURL }}"` → `href="{{ "docs/tutorials/quick-start" | relURL }}"`