### PR TITLE
fix: updates stylelint-config-standard to fix deps conflict

### DIFF
--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -37,7 +37,7 @@
 {{ $showFlexSearch := .Site.Params.options.flexSearch }}
 
 {{ if $showFlexSearch -}}
-  {{ $flexSearch := resources.Get "js/vendor/flexsearch/dist/flexsearch.bundle.js" -}}
+  {{ $flexSearch := resources.Get "js/vendor/flexsearch/dist/flexsearch.bundle.min.js" -}}
   {{ $slice = $slice | append $flexSearch -}}
   {{ if and (isset .Site.Params.options "searchsectionsshow") (not (eq .Site.Params.options.searchSectionsShow "ALL")) -}}
   {{ $showFlexSearch = or (eq (len .Site.Params.options.searchSectionsShow) 0) (in .Site.Params.options.searchSectionsShow .Section) (and .IsHome (in .Site.Params.options.searchSectionsShow "HomePage")) -}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "purgecss-whitelister": "2.4.0",
         "shx": "0.3.4",
         "stylelint": "16.10.0",
-        "stylelint-config-standard": "33.0.0"
+        "stylelint-config-standard": "36.0.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7308,25 +7308,53 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/stylelint-config-standard": {
-      "version": "33.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-33.0.0.tgz",
-      "integrity": "sha512-eyxnLWoXImUn77+ODIuW9qXBDNM+ALN68L3wT1lN2oNspZ7D9NVGlNHb2QCUn4xDug6VZLsh0tF8NyoYzkgTzg==",
+    "node_modules/stylelint-config-recommended": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
+      "integrity": "sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==",
       "dev": true,
-      "dependencies": {
-        "stylelint-config-recommended": "^12.0.0"
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "stylelint": "^15.5.0"
+        "stylelint": "^16.1.0"
       }
     },
-    "node_modules/stylelint-config-standard/node_modules/stylelint-config-recommended": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
-      "integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
+    "node_modules/stylelint-config-standard": {
+      "version": "36.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz",
+      "integrity": "sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "stylelint-config-recommended": "^14.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
       "peerDependencies": {
-        "stylelint": "^15.5.0"
+        "stylelint": "^16.1.0"
       }
     },
     "node_modules/stylelint/node_modules/balanced-match": {
@@ -13247,22 +13275,20 @@
         }
       }
     },
+    "stylelint-config-recommended": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
+      "integrity": "sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==",
+      "dev": true,
+      "requires": {}
+    },
     "stylelint-config-standard": {
-      "version": "33.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-33.0.0.tgz",
-      "integrity": "sha512-eyxnLWoXImUn77+ODIuW9qXBDNM+ALN68L3wT1lN2oNspZ7D9NVGlNHb2QCUn4xDug6VZLsh0tF8NyoYzkgTzg==",
+      "version": "36.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz",
+      "integrity": "sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==",
       "dev": true,
       "requires": {
-        "stylelint-config-recommended": "^12.0.0"
-      },
-      "dependencies": {
-        "stylelint-config-recommended": {
-          "version": "12.0.0",
-          "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
-          "integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
-          "dev": true,
-          "requires": {}
-        }
+        "stylelint-config-recommended": "^14.0.1"
       }
     },
     "stylis": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4383,7 +4383,8 @@
       "version": "0.7.43",
       "resolved": "https://registry.npmjs.org/flexsearch/-/flexsearch-0.7.43.tgz",
       "integrity": "sha512-c5o/+Um8aqCSOXGcZoqZOm+NqtVwNsvVpWv6lfmSclU954O3wvQKxxK8zj74fPaSJbXpSLTs4PRhh+wnoCXnKg==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/foreground-child": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "purgecss-whitelister": "2.4.0",
     "shx": "0.3.4",
     "stylelint": "16.10.0",
-    "stylelint-config-standard": "33.0.0"
+    "stylelint-config-standard": "36.0.1"
   },
   "otherDependencies": {
     "hugo": "0.87.0"


### PR DESCRIPTION
The sneaky renovatebot managed to self-approve and merge a broken PR: https://github.com/corazawaf/coraza.io/pull/300. Now CI is failing, e.g. https://github.com/corazawaf/coraza.io/pull/301.

This PR should fix the conflict.

Would be good to add the CI pass requirement for merging. 