### PR TITLE
chore(ci): harden GHA workflows with least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,19 @@ on:
       - "LICENSE"
       - "README.md"
   pull_request:
+    branches:
+      - "main"
     paths-ignore:
       - "LICENSE"
       - "README.md"
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Install Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,13 @@ on:
     branches:
       - main  # Set a branch to deploy
 
+permissions: {}
+
 jobs:
   deploy:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,13 +6,14 @@ on:
       - .github/workflows/update.yml
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   create-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Install Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
@@ -32,10 +33,12 @@ jobs:
           echo "short=$(gh api repos/corazawaf/coraza/commits/main -q .sha | cut -c 1-8)" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+
       - name: Pull latest coraza
+        env:
+          CORAZA_COMMIT: ${{ steps.coraza-latest-commit.outputs.long }}
         run: |
-          go get -u github.com/corazawaf/coraza/v3@${{ steps.coraza-latest-commit.outputs.long }}
+          go get -u github.com/corazawaf/coraza/v3@"${CORAZA_COMMIT}"
           go mod tidy
 
       - name: Tests and coverage
@@ -57,17 +60,20 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           CHANGED_FILES: ${{ steps.verify-changed-files.outputs.changed_files }}
+          CORAZA_SHORT: ${{ steps.coraza-latest-commit.outputs.short }}
+          CORAZA_LONG: ${{ steps.coraza-latest-commit.outputs.long }}
+          ACTOR: ${{ github.actor }}
         run: |
           cat <<EOF > $GITHUB_STEP_SUMMARY
           # Changed files:
           $CHANGED_FILES
 
           # PR information:
-          **commit-message**: docs: upgrades coraza docs to github.com/corazawaf/coraza/v3@${{ steps.coraza-latest-commit.outputs.short }}
-          **branch**: upgrades_coraza_${{ steps.coraza-latest-commit.outputs.short }}
+          **commit-message**: docs: upgrades coraza docs to github.com/corazawaf/coraza/v3@${CORAZA_SHORT}
+          **branch**: upgrades_coraza_${CORAZA_SHORT}
           **title**: docs: upgrades to latest coraza
-          **assignees**: ${{ github.actor }}
-          **body**: This PR upgrades the docs to latest coraza commit namely [${{ steps.coraza-latest-commit.outputs.short }}](https://github.com/corazawaf/coraza/tree/${{ steps.coraza-latest-commit.outputs.long }})
+          **assignees**: ${ACTOR}
+          **body**: This PR upgrades the docs to latest coraza commit namely [${CORAZA_SHORT}](https://github.com/corazawaf/coraza/tree/${CORAZA_LONG})
           EOF
 
       - name: Create Pull Request
@@ -86,5 +92,7 @@ jobs:
 
       - name: Check outputs
         if: ${{ github.event_name != 'pull_request' && steps.create-pr.outputs.pull-request-number }}
+        env:
+          PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
         run: |
-          echo "Created PR at ${{ steps.create-pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+          echo "Created PR at ${PR_URL}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

| Workflow | Change |
|----------|--------|
| `ci.yml` | Added `permissions: {}` top-level, `contents: read` at job level, added `branches: [main]` to `pull_request` trigger |
| `deploy.yml` | Added `permissions: {}` top-level, `contents: write` at job level (required by `peaceiris/actions-gh-pages`) |
| `update.yml` | Moved `contents: write` + `pull-requests: write` from top-level to job-level, set top-level to `permissions: {}` |
| All | Fixed expression injection: replaced `${{ }}` interpolations in `run:` blocks with environment variables in `update.yml` (steps: "Pull latest coraza", "List changed files", "Check outputs") |

All actions were already pinned to SHA. No new pins needed.